### PR TITLE
Fix not seeing response from proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ go run cli/main.go
 
 which will open an http server on port 8085
 
-Note: next step is broken, need to fix it 4. In another terminal `curl localhost:8085` will respond with "hello world"
+4. In a separate terminal
+
+```
+curl -X POST localhost:8085 -H "Content-Type: application/json" -H "X-Mirror-Body: true" -d '{"productId": 123456, "quantity": 100}'
+```
+
+`X-Mirror-Body: true` makes the dummy server return the body of the request as the response.
 
 # Overall architecture
 

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -163,7 +163,6 @@ func (s *Server) newHTTPProxy(req *ssh.Request) {
 	// Start new http listener on an ephemeral port
 	p, _ := proxy.NewHTTPProxy(":0", target, dialer, s.log)
 	go func() {
-		p.ListenAndServe()
 	}()
 
 	log.Infow("HTTP Proxy started", "hostport", p.ListenerHost())


### PR DESCRIPTION
- proxy.ListenAndServe needs initializes the proxy listener. running it in a goroutine all together would mean the listener is not initialized, and we need tot access the address from the listener. Reverted back to using a go routine just to start the server in the proxy, and not wrapping proxy.ListenAndServe in a goroutine
- updated readme