### PR TITLE
enable pubkey ssh auth + add -p (Port) option

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,12 +18,13 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"github.com/spf13/cobra"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 var cfgFile string
+var ProxyPort string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -54,6 +55,7 @@ func init() {
 	// will be global for your application.
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cli.yaml)")
+	rootCmd.PersistentFlags().StringVar(&ProxyPort, "port", "8085", "port for http proxy to listen on")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.

--- a/cli/main.go
+++ b/cli/main.go
@@ -20,9 +20,12 @@ package main
 import (
 	"bufio"
 	"context"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -50,17 +53,24 @@ type logDecoder interface {
 
 func sshclient(logger *zap.SugaredLogger) {
 
-	// TODO we need to make this work with a public key, not a password
-	logger.Info("Dialing 8023...")
+	// Load the private key
+	privateKeyPath := "private_unencrypted.pem"
+	signer, err := loadPrivateKey(privateKeyPath)
+	if err != nil {
+		log.Fatal("Failed to load private key:", err)
+	}
+
 	config := &ssh.ClientConfig{
 		User: "testuser",
 		Auth: []ssh.AuthMethod{
-			ssh.Password("tiger"),
+			// ssh.Password("tiger"),
+			ssh.PublicKeys(signer),
 		},
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //hostKeyCallback, //ssh.FixedHostKey(hostKey),
 	}
 
 	// Dial your ssh server.
+	logger.Info("Dialing 8023...")
 	connAuth, err := ssh.Dial("tcp", "127.0.0.1:8023", config)
 	if err != nil {
 		logger.Fatal(err, "unable to connect: ")
@@ -187,7 +197,7 @@ func sshclient(logger *zap.SugaredLogger) {
 
 	// Serve HTTP with your SSH server acting as a reverse proxy.
 	// payload has the hostport
-	p, _ := proxy.NewHTTPProxy(":8085", string(payload), proxy.Dialer(func(ctx context.Context, n string, addr string) (net.Conn, error) {
+	p, _ := proxy.NewHTTPProxy(fmt.Sprintf(":%s", cmd.ProxyPort), string(payload), proxy.Dialer(func(ctx context.Context, n string, addr string) (net.Conn, error) {
 		logger.Infow("Dialing...", "addr", addr)
 		newChannel, err := conn.Dial("tcp", addr)
 		if err != nil {
@@ -206,6 +216,30 @@ func sshclient(logger *zap.SugaredLogger) {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	<-c
+}
+
+func loadPrivateKey(privateKeyPath string) (ssh.Signer, error) {
+	keyBytes, err := ioutil.ReadFile(privateKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	block, _ := pem.Decode(keyBytes)
+	if block == nil {
+		return nil, err
+	}
+
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	signer, err := ssh.NewSignerFromKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	return signer, nil
 }
 
 func madTCPProxyThing() {
@@ -275,7 +309,6 @@ func main() {
 	// logger.Fatal(err)
 	// }
 
-	sshclient(logger)
-
 	cmd.Execute()
+	sshclient(logger)
 }

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -12,15 +12,15 @@ RUN useradd -m testuser && \
 RUN mkdir /var/run/sshd && \
     echo 'Port 8023' >> /etc/ssh/sshd_config && \
     echo 'PermitRootLogin no' >> /etc/ssh/sshd_config && \
-    echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config && \
+    echo 'PubkeyAuthentication yes' >> /etc/ssh/sshd_config && \
     echo 'AllowTcpForwarding yes' >> /etc/ssh/sshd_config && \
     echo 'PermitTunnel yes' >> /etc/ssh/sshd_config && \
     echo 'PermitTTY no' >> /etc/ssh/sshd_config && \
     echo 'Match User testuser' >> /etc/ssh/sshd_config 
-# && \
-# echo '    ForceCommand /bin/gateway' >> /etc/ssh/sshd_config
-
-
+    # && \
+    # echo 'LogLevel DEBUG3' >> /etc/ssh/sshd_config
+    # && \
+    # echo '    ForceCommand /bin/gateway' >> /etc/ssh/sshd_config
 
 # Set the Current Working Directory inside the container
 WORKDIR /app
@@ -30,6 +30,10 @@ WORKDIR /app
 
 # Copy the source from the current directory to the Working Directory inside the container
 COPY ./ ./
+
+# Add public key to authorized_keys file to enable pubkey auth
+RUN mkdir /home/testuser/.ssh && \
+    ssh-keygen -y -f /app/private_unencrypted.pem > /home/testuser/.ssh/authorized_keys
 
 # Download all dependencies. Dependencies will be cached if the go.mod and go.sum files are not changed
 RUN go mod download
@@ -48,4 +52,4 @@ EXPOSE 8023
 # CMD ["/bin/gateway"]
 
 # Start SSH server
-CMD ["/usr/sbin/sshd", "-D"]
+CMD ["/usr/sbin/sshd", "-De"]

--- a/gateway/server.go
+++ b/gateway/server.go
@@ -29,28 +29,27 @@ type Server struct {
 func NewServer(log *zap.SugaredLogger) (*Server, error) {
 	config := &ssh.ServerConfig{
 		// Remove to disable password auth.
-		PasswordCallback: func(c ssh.ConnMetadata, pass []byte) (*ssh.Permissions, error) {
-			// Should use constant-time compare (or better, salt+hash) in
-			// a production setting.
-			log.Infow("Checking handshake")
-			if c.User() == "testuser" && string(pass) == "tiger" {
-				return nil, nil
-			}
-			return nil, fmt.Errorf("password rejected for %q", c.User())
-		},
+		// PasswordCallback: func(c ssh.ConnMetadata, pass []byte) (*ssh.Permissions, error) {
+		// 	// Should use constant-time compare (or better, salt+hash) in
+		// 	// a production setting.
+		// 	log.Infow("Checking handshake")
+		// 	if c.User() == "testuser" && string(pass) == "tiger" {
+		// 		return nil, nil
+		// 	}
+		// 	return nil, fmt.Errorf("password rejected for %q", c.User())
+		// },
 
 		// Remove to disable public key auth.
-		//	PublicKeyCallback: func(c ssh.ConnMetadata, pubKey ssh.PublicKey) (*ssh.Permissions, error) {
-		//		if authorizedKeysMap[string(pubKey.Marshal())] {
-		//			return &ssh.Permissions{
-		//				// Record the public key used for authentication.
-		//				Extensions: map[string]string{
-		//					"pubkey-fp": ssh.FingerprintSHA256(pubKey),
-		//				},
-		//			}, nil
-		//		}
-		//		return nil, fmt.Errorf("unknown public key for %q", c.User())
-		//	},
+		PublicKeyCallback: func(c ssh.ConnMetadata, pubKey ssh.PublicKey) (*ssh.Permissions, error) {
+			fmt.Println("Public key:", string(ssh.MarshalAuthorizedKey(pubKey)))
+
+			return &ssh.Permissions{
+				// Record the public key used for authentication.
+				Extensions: map[string]string{
+					"pubkey-fp": ssh.FingerprintSHA256(pubKey),
+				},
+			}, nil
+		},
 	}
 
 	privateBytes, err := ioutil.ReadFile("/run/secrets/id_rsa")


### PR DESCRIPTION
- SSH pubkey auth still using unencrypted PEM
- Adding option -p to select port for proxy to listen on instead of default 8085